### PR TITLE
Refactor: Use named_tuple for NoteInfo instead of array

### DIFF
--- a/DexmoPiano/errorCalc.py
+++ b/DexmoPiano/errorCalc.py
@@ -15,7 +15,7 @@ def computeError(targetNoteInfoList, actualNoteInfoList):
 		tempSum = 0
 
 		for noteInfo in noteInfoList:
-			tempSum += noteInfo[3] - noteInfo[2]
+			tempSum += noteInfo.note_off_time - noteInfo.note_on_time
 
 		timeSums.append(round(tempSum, 3))
 

--- a/DexmoPiano/midiInput.py
+++ b/DexmoPiano/midiInput.py
@@ -2,6 +2,23 @@ import mido
 
 import noteHandler as nh
 
+from collections import namedtuple, defaultdict
+
+
+NoteInfo = namedtuple("NoteInfo", ["pitch", "velocity", "note_on_time", "note_off_time"])
+empty_noteinfo = lambda: NoteInfo(-1,-1,-1,-1)
+
+def adapt_noteinfo(source, pitch=None, note_on_time=None, note_off_time=None,
+                   velocity=None):
+    d = source._asdict()
+    for var, name in [(pitch, "pitch"), (note_on_time, "note_on_time"), 
+                       (note_off_time, "note_off_time"), (velocity, "velocity")]:
+        if var is not None:
+            d[name] = var
+    
+    return NoteInfo(**d)
+                     
+                       
 
 class MidiInputThread():
     """
@@ -11,7 +28,7 @@ class MidiInputThread():
     ###TODO: remove
     testPort = ""
 
-    def __init__(self, tempSize):
+    def __init__(self):
         """
         Initializes necessary variables and note lists/arrays.
 
@@ -19,10 +36,9 @@ class MidiInputThread():
         """
         #threading.Thread.__init__(self)
         self.inport = None
-        self.tempSize = tempSize
         # initialize note array and list
         self.noteInfoList = []
-        self.noteInfoTemp = [[-1, -1, -1]] * self.tempSize
+        self.noteInfoTemp = defaultdict(empty_noteinfo)
 
         # only handle input if true
         self.handleInput = False
@@ -96,7 +112,7 @@ class MidiInputThread():
         @return: None
         """
         self.noteInfoList = []
-        self.noteInfoTemp = [[-1, -1, -1]] * self.tempSize
+        self.noteInfoTemp.clear()
 
     def inputOn(self):
         """

--- a/DexmoPiano/noteHandler.py
+++ b/DexmoPiano/noteHandler.py
@@ -1,7 +1,5 @@
 import time
 
-from midiInput import adapt_noteinfo
-
 # number of digits up to which a float is rounded
 ROUND_DIGITS = 3
 
@@ -47,6 +45,8 @@ def handleNote(noteType, pitch, velocity, noteInfoTemp, noteInfoList):
     @param noteInfoList: List of all notes played by the user.
     @return: -1 for error, 0 for note_on success, noteInfo for note_off success
     """
+    
+    from midiInput import adapt_noteinfo
     
     # the NoteInfo object before any updates
     note_info = noteInfoTemp[pitch]

--- a/DexmoPiano/threadHandler.py
+++ b/DexmoPiano/threadHandler.py
@@ -1,12 +1,12 @@
 from threading import Thread
 
 import dexmoOutput
-from midiInput import MidiInputThread
+from midiInput import MidiInputThread, empty_noteinfo
 import errorCalc
 
+from collections import defaultdict
 
 # GLOBAL CONSTANTS
-MAX_NOTE = 128
 global portname
 
 
@@ -26,7 +26,7 @@ def resetArrays():
 	# initialize list of tuples for note on/off times
 	# index = note: [t_on, t_off, velocity]
 	###TODO: documentation (temporary etc.)
-	targetTemp = [[-1, -1, -1]] * MAX_NOTE
+	targetTemp = defaultdict(empty_noteinfo)
 
 
 def initInputThread():
@@ -38,7 +38,7 @@ def initInputThread():
 	global inputThread
 
 	# create inputThread instance (port is set to None in constructor)
-	inputThread = MidiInputThread(MAX_NOTE)	
+	inputThread = MidiInputThread()	
 
 def set_inport(portName):
 	"""


### PR DESCRIPTION
NoteInfo objects now use named_tuples, allowing for things like:
`tempSum += noteInfo.note_off_time - noteInfo.note_on_time`

instead of 
`tempSum += noteInfo[3] - noteInfo[2]`

(note that because the underlying data structure is a tuple, the old index access would still work. I nevertheless refactored all the uses I found in the code)

This does change the XML output, not sure if it was used for more than just debugging so far.